### PR TITLE
ignore IDEs workspace folders

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -136,3 +136,7 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# IDEs
+.idea/
+.vscode/


### PR DESCRIPTION
When you open a project with any of JetBrains IDEs it will create a folder called `.idea` that contains your workspace settings,
and the same goes for VSCode with the folder name `vscode`.

**Reasons for making this change:**

_TODO_

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
